### PR TITLE
allow for using an existing secret for the secret for hashes

### DIFF
--- a/deployments/kubernetes/chart/gitwebhookproxy/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/gitwebhookproxy/templates/deployment.yaml
@@ -83,7 +83,9 @@ spec:
           valueFrom:
             secretKeyRef:
               key: secret
-            {{- if .Values.gitWebhookProxy.useCustomName }}
+            {{- if .Values.gitWebhookProxy.existingSecretName }}
+              name: {{ .Values.gitWebhookProxy.existingSecretName }}
+            {{- else if .Values.gitWebhookProxy.useCustomName }}
               name: {{ .Values.gitWebhookProxy.customName }}
             {{- else }}
               name: {{ template "gitwebhookproxy.name" . }}

--- a/deployments/kubernetes/chart/gitwebhookproxy/templates/secret.yaml
+++ b/deployments/kubernetes/chart/gitwebhookproxy/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.gitWebhookProxy.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,3 +12,4 @@ metadata:
 {{- end }}
 data:
     secret: "{{ .Values.gitWebhookProxy.config.secret | b64enc }}"
+{{- end }}

--- a/deployments/kubernetes/chart/gitwebhookproxy/values.yaml
+++ b/deployments/kubernetes/chart/gitwebhookproxy/values.yaml
@@ -7,6 +7,8 @@ gitWebhookProxy:
   useCustomName: false
   customName: gitlabwebhookproxy
   namespace: default
+  # name of existing secret containing secret for hashes
+  existingSecretName: ""
   labels:
     provider: stakater
     group: com.stakater.platform

--- a/deployments/kubernetes/templates/chart/values.yaml.tmpl
+++ b/deployments/kubernetes/templates/chart/values.yaml.tmpl
@@ -7,6 +7,8 @@ gitWebhookProxy:
   useCustomName: false
   customName: gitlabwebhookproxy
   namespace: default
+  # name of existing secret containing secret for hashes
+  existingSecretName: ""
   labels:
     provider: stakater
     group: com.stakater.platform


### PR DESCRIPTION
This helps keep the secret - useful when handling this via other mechanisms and doing gitops on the chart.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stakater/gitwebhookproxy/82)
<!-- Reviewable:end -->
