### PR TITLE
skip json parsing if allowedUser or ignoredUser are empty

### DIFF
--- a/pkg/providers/gitlab.go
+++ b/pkg/providers/gitlab.go
@@ -63,7 +63,7 @@ func (p *GitlabProvider) Validate(hook Hook) bool {
 func (p *GitlabProvider) GetCommitter(hook Hook) string {
 	var payloadData GitlabPushPayload
 	if err := json.Unmarshal(hook.Payload, &payloadData); err != nil {
-		log.Printf("Gitlab hook payload unmarshalling failed")
+		log.Printf("Gitlab hook payload unmarshalling failed: %v", err)
 		return ""
 	}
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -142,13 +142,15 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request, params http
 		return
 	}
 
-	committer := provider.GetCommitter(*hook)
-	log.Printf("Incoming request from user: %s", committer)
-	if p.isIgnoredUser(committer) || (!p.isAllowedUser(committer)) {
-		log.Printf("Ignoring request for user: %s", committer)
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(fmt.Sprintf("Ignoring request for user: %s", committer)))
-		return
+	if len(p.ignoredUsers) > 0 || len(p.allowedUsers) > 0 {
+		committer := provider.GetCommitter(*hook)
+		log.Printf("Incoming request from user: %s", committer)
+		if p.isIgnoredUser(committer) || (!p.isAllowedUser(committer)) {
+			log.Printf("Ignoring request for user: %s", committer)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(fmt.Sprintf("Ignoring request for user: %s", committer)))
+			return
+		}
 	}
 
 	if len(strings.TrimSpace(p.secret)) > 0 && !provider.Validate(*hook) {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	proxyGitlabTestSecret = "testSecret"
-	proxyGitlabTestEvent  = "testEvent"
+	proxyGitlabTestEvent  = "Push Hook"
 	proxyGitlabTestBody   = "testBody"
 	httpBinURL            = "httpbin.org"
 	httpBinURLInsecure    = "http://" + httpBinURL
@@ -468,6 +468,7 @@ func TestProxy_proxyRequest(t *testing.T) {
 		upstreamURL  string
 		allowedPaths []string
 		secret       string
+		allowedUsers []string
 	}
 	type args struct {
 		request *http.Request
@@ -618,6 +619,21 @@ func TestProxy_proxyRequest(t *testing.T) {
 			wantStatusCode: http.StatusOK,
 		},
 		{
+			name: "TestProxyRequestShouldParseJsonWithAllowedOrIgnoredUsersConfigured",
+			fields: fields{
+				provider:     providers.GitlabProviderKind,
+				upstreamURL:  httpBinURLSecure,
+				allowedPaths: []string{},
+				secret:       "",
+				allowedUsers: []string{"jsmith"},
+			},
+			args: args{
+				request: createGitlabRequestWithPayload(http.MethodPost, "/post",
+					proxyGitlabTestSecret, proxyGitlabTestEvent, proxyGitlabTestPayload),
+			},
+			wantStatusCode: http.StatusOK,
+		},
+		{
 			name: "TestProxyRequestWithInvalidHttpMethod",
 			fields: fields{
 				provider:     providers.GitlabProviderKind,
@@ -751,6 +767,7 @@ func TestProxy_proxyRequest(t *testing.T) {
 				upstreamURL:  tt.fields.upstreamURL,
 				allowedPaths: tt.fields.allowedPaths,
 				secret:       tt.fields.secret,
+				allowedUsers: tt.fields.allowedUsers,
 			}
 			router := httprouter.New()
 			router.POST("/*path", p.proxyRequest)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -604,6 +604,20 @@ func TestProxy_proxyRequest(t *testing.T) {
 			wantStatusCode: http.StatusMethodNotAllowed,
 		},
 		{
+			name: "TestProxyRequestShouldNotParseJsonWithoutAllowedOrIgnoredUsersConfigured",
+			fields: fields{
+				provider:     providers.GitlabProviderKind,
+				upstreamURL:  httpBinURLSecure,
+				allowedPaths: []string{},
+				secret:       "",
+			},
+			args: args{
+				request: createGitlabRequestWithPayload(http.MethodPost, "/post",
+					proxyGitlabTestSecret, proxyGitlabTestEvent, []byte("{}")),
+			},
+			wantStatusCode: http.StatusOK,
+		},
+		{
 			name: "TestProxyRequestWithInvalidHttpMethod",
 			fields: fields{
 				provider:     providers.GitlabProviderKind,


### PR DESCRIPTION
We are running github enterprise, therefor the github payload cannot be parsed cause the payload has an additional property enterprise. This pull requests introduces skipping of json parsing if no allowedUser and ignoredUser are empty