### PR TITLE
Allow for adding a TLS secretName

### DIFF
--- a/deployments/kubernetes/chart/gitwebhookproxy/templates/ingress.yaml
+++ b/deployments/kubernetes/chart/gitwebhookproxy/templates/ingress.yaml
@@ -30,4 +30,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.gitWebhookProxy.ingress.host }}
+  {{- if .Values.gitWebhookProxy.ingress.tlsSecretName }}
+    secretName: {{ .Values.gitWebhookProxy.ingress.tlsSecretName }}
+  {{- end }}
 {{- end }}

--- a/deployments/kubernetes/chart/gitwebhookproxy/values.yaml
+++ b/deployments/kubernetes/chart/gitwebhookproxy/values.yaml
@@ -40,5 +40,6 @@ gitWebhookProxy:
       kubernetes.io/ingress.class: external-ingress
       monitor.stakater.com/enabled: "true"
     host: gitwebhookproxy.tools.stackator.com
+    tlsSecretName: ""
     serviceName: gitwebhookproxy
     servicePort: 80

--- a/deployments/kubernetes/templates/chart/values.yaml.tmpl
+++ b/deployments/kubernetes/templates/chart/values.yaml.tmpl
@@ -40,5 +40,6 @@ gitWebhookProxy:
       kubernetes.io/ingress.class: external-ingress
       monitor.stakater.com/enabled: "true"
     host: gitwebhookproxy.tools.stackator.com
+    tlsSecretName: ""
     serviceName: gitwebhookproxy
     servicePort: 80


### PR DESCRIPTION
Firstly, thank you so much for making a great project like this!

We are using [cert manager](https://cert-manager.io/docs/usage/ingress/) to manage our ingress TLS certificates using Let's Encrypt. In order to get this to work in our cluster, I needed to add some custom ingress annotations to our values.yaml, but then I also had to manually patch the ingress with name of the secret it should store the TLS cert in after I deployed with helm.

These changes would allow a helm chart provisioner the ability to supply this value if needed.

