### PR TITLE
remove namespace from ingress template

### DIFF
--- a/deployments/kubernetes/chart/gitwebhookproxy/templates/ingress.yaml
+++ b/deployments/kubernetes/chart/gitwebhookproxy/templates/ingress.yaml
@@ -14,7 +14,6 @@ metadata:
 {{- else }}
   name: {{ template "gitwebhookproxy.name" . }}
 {{- end }}
-  namespace: {{ .Values.gitWebhookProxy.namespace }}
 spec:
   rules:
   - host: {{ .Values.gitWebhookProxy.ingress.host }}


### PR DESCRIPTION
or use  {{ Release.Namespace }}, but in that case it should be added to all templates to be consistent