### PR TITLE
Remove namespace

### DIFF
--- a/deployments/kubernetes/chart/gitwebhookproxy/templates/deployment.yaml
+++ b/deployments/kubernetes/chart/gitwebhookproxy/templates/deployment.yaml
@@ -34,9 +34,7 @@ spec:
       containers:
       - env:
         - name: KUBERNETES_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: {{ .Release.Namespace }}
         - name: GWP_PROVIDER
           valueFrom:
             configMapKeyRef:

--- a/deployments/kubernetes/chart/gitwebhookproxy/values.yaml
+++ b/deployments/kubernetes/chart/gitwebhookproxy/values.yaml
@@ -6,7 +6,6 @@ kubernetes:
 gitWebhookProxy:
   useCustomName: false
   customName: gitlabwebhookproxy
-  namespace: default
   # name of existing secret containing secret for hashes
   existingSecretName: ""
   labels:

--- a/deployments/kubernetes/templates/chart/values.yaml.tmpl
+++ b/deployments/kubernetes/templates/chart/values.yaml.tmpl
@@ -6,7 +6,6 @@ kubernetes:
 gitWebhookProxy:
   useCustomName: false
   customName: gitlabwebhookproxy
-  namespace: default
   # name of existing secret containing secret for hashes
   existingSecretName: ""
   labels:


### PR DESCRIPTION
- remove the fixed namespace from helm/k8s files and use ".Release.Namespace" instead (this is a namespace which is defined when installing deployment to k8s cluster)
- it is never a good solution to fix namespace in chart file