### PR TITLE
Allow configure HTTP Proxy from env vars

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -20,6 +20,7 @@ import (
 
 var (
 	transport = &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	httpClient = &http.Client{


### PR DESCRIPTION
By default, Golang's HTTP client uses any http proxy configured via
HTTP_PROXY or HTTPS_PROXY environment variables. In this project,
transport is ovewritten and does not use the default transport. This
means that proxy environment variables get ignored.

With the proposed change, http client will be built with go's default
proxy configuration, which gives more flexibility to the users.