### PR TITLE
feat: handle event not related to committer

### DIFF
--- a/.VERSION
+++ b/.VERSION
@@ -1,1 +1,1 @@
-version: v0.2.80
+version: v0.2.82

--- a/pkg/providers/github.go
+++ b/pkg/providers/github.go
@@ -72,13 +72,21 @@ func (p *GithubProvider) GetProviderName() string {
 	return GithubName
 }
 
-func (p *GithubProvider) GetCommitter(hook Hook) string {
+func (p *GithubProvider) GetEventType(hook Hook) Event {
 	eventType := Event(hook.Headers[XGitHubEvent])
+	log.Printf("Received event type: %v", eventType)
+	return eventType
+}
+
+func (p *GithubProvider) IsCommitterCheckEvent(event Event) bool {
+	return event == GithubPushEvent || event == GithubPullRequestEvent || event == GithubIssueCommentEvent
+}
+
+func (p *GithubProvider) GetCommitter(hook Hook, eventType Event) string {
 	var pushPayloadData GithubPushPayload
 	var pullRequestPayloadData GithubPullRequestPayload
 	var issueCommentPayloadData GithubIssueCommentPayload
 
-	log.Printf("Received event type: %v", eventType)
 	switch eventType {
 	case GithubPushEvent:
 		if err := json.Unmarshal(hook.Payload, &pushPayloadData); err != nil {

--- a/pkg/providers/gitlab.go
+++ b/pkg/providers/gitlab.go
@@ -60,14 +60,22 @@ func (p *GitlabProvider) Validate(hook Hook) bool {
 	return strings.TrimSpace(token) == strings.TrimSpace(p.secret)
 }
 
-func (p *GitlabProvider) GetCommitter(hook Hook) string {
+func (p *GitlabProvider) GetEventType(hook Hook) Event {
+	event := Event(hook.Headers[XGitlabEvent])
+	log.Printf("Received event type: %v", event)
+	return event
+}
+
+func (p *GitlabProvider) IsCommitterCheckEvent(event Event) bool {
+	return event == GitlabPushEvent
+}
+
+func (p *GitlabProvider) GetCommitter(hook Hook, eventType Event) string {
 	var payloadData GitlabPushPayload
 	if err := json.Unmarshal(hook.Payload, &payloadData); err != nil {
 		log.Printf("Gitlab hook payload unmarshalling failed")
 		return ""
 	}
-
-	eventType := Event(hook.Headers[XGitlabEvent])
 	switch eventType {
 	case GitlabPushEvent:
 		return payloadData.Username

--- a/pkg/providers/provider.go
+++ b/pkg/providers/provider.go
@@ -18,7 +18,9 @@ type Event string
 type Provider interface {
 	GetHeaderKeys() []string
 	Validate(hook Hook) bool
-	GetCommitter(hook Hook) string
+	GetEventType(hook Hook) Event
+	IsCommitterCheckEvent(event Event) bool
+	GetCommitter(hook Hook, eventType Event) string
 	GetProviderName() string
 }
 
@@ -29,7 +31,7 @@ func assertProviderImplementations() {
 
 func NewProvider(provider string, secret string) (Provider, error) {
 	if len(provider) == 0 {
-		return nil, errors.New("Empty provider string specified")
+		return nil, errors.New("empty provider string specified")
 	}
 
 	switch strings.ToLower(provider) {
@@ -38,7 +40,7 @@ func NewProvider(provider string, secret string) (Provider, error) {
 	case GitlabProviderKind:
 		return NewGitlabProvider(secret)
 	default:
-		return nil, errors.New("Unknown Git Provider '" + provider + "' specified")
+		return nil, errors.New("unknown Git Provider '" + provider + "' specified")
 	}
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -143,13 +143,15 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request, params http
 		return
 	}
 
-	committer := provider.GetCommitter(*hook)
-	log.Printf("Incoming request from user: %s", committer)
-	if p.isIgnoredUser(committer) || (!p.isAllowedUser(committer)) {
-		log.Printf("Ignoring request for user: %s", committer)
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(fmt.Sprintf("Ignoring request for user: %s", committer)))
-		return
+	if event := provider.GetEventType(*hook); provider.IsCommitterCheckEvent(event) {
+		committer := provider.GetCommitter(*hook, event)
+		log.Printf("Incoming request from user: %s", committer)
+		if p.isIgnoredUser(committer) || (!p.isAllowedUser(committer)) {
+			log.Printf("Ignoring request for user: %s", committer)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(fmt.Sprintf("Ignoring request for user: %s", committer)))
+			return
+		}
 	}
 
 	if len(strings.TrimSpace(p.secret)) > 0 && !provider.Validate(*hook) {


### PR DESCRIPTION
#92 

This PR will relay all the other events that are not supported currently to upstream without checking committers.

